### PR TITLE
Set basedir to DITA-OT dir for integrator.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -111,7 +111,7 @@
 			</fileset>
 		</copy>
     <!-- Integrate the deployed plugins: -->
-    <ant antfile="${dita-ot-dir}/integrator.xml" target="integrate"/>
+    <ant dir="${dita-ot-dir}" antfile="integrator.xml" target="integrate"/>
 
 	</target>
 	


### PR DESCRIPTION
It fixes an issue with DITA-OT 2.x although it's not officially supported. The new version works with both DITA-OT 1.x and DITA-OT 2.x, tested with 1.8.5 and 2.0.1.

P.S. I use these plug-ins with DITA-OT 2.x to enable MathML support as DITA 1.3 spec is still not completely implemented.
